### PR TITLE
Containerize and deploy to Cloud Run

### DIFF
--- a/classifier/Dockerfile
+++ b/classifier/Dockerfile
@@ -1,0 +1,21 @@
+# Use the official lightweight Python image.
+# https://hub.docker.com/_/python
+FROM python:3.7-slim
+
+# Allow statements and log messages to immediately appear in the Knative logs
+ENV PYTHONUNBUFFERED True
+
+# Copy local code to the container image.
+ENV APP_HOME /app
+WORKDIR $APP_HOME
+COPY . ./
+
+# Install production dependencies.
+RUN pip install --no-cache-dir -r requirements.txt
+
+# Run the web service on container startup. Here we use the gunicorn
+# webserver, with one worker process and 8 threads.
+# For environments with multiple CPU cores, increase the number of workers
+# to be equal to the cores available.
+# Timeout is set to 0 to disable the timeouts of the workers to allow Cloud Run to handle instance scaling.
+CMD exec gunicorn --bind :$PORT --workers 1 --threads 8 --timeout 0 main:app

--- a/classifier/cloudbuild.yaml
+++ b/classifier/cloudbuild.yaml
@@ -1,0 +1,22 @@
+# containerize the module and deploy it to Cloud Run
+steps:
+# build the container image
+- name: 'gcr.io/cloud-builders/docker'
+  args: ['build', '-t', '${_MODULE_IMAGE_NAME}', '.']
+# push the image to Container Registry
+- name: 'gcr.io/cloud-builders/docker'
+  args: ['push', '${_MODULE_IMAGE_NAME}']
+# deploy the image to Cloud Run
+- name: 'gcr.io/google.com/cloudsdktool/cloud-sdk'
+  entrypoint: gcloud
+  args: ['run', 'deploy', '${_MODULE_NAME}', '--image', '${_MODULE_IMAGE_NAME}', '--region', '${_REGION}', '--set-env-vars', '${_ENV_VARS}']
+substitutions:
+    _SURVEY: 'elasticc'
+    _TESTID: '-testid'
+    _MODULE_NAME: 'classifier${_TESTID}'
+    _MODULE_IMAGE_NAME: 'gcr.io/${PROJECT_ID}/${_MODULE_NAME}'
+    _ENV_VARS: 'GCP_PROJECT=${PROJECT_ID},SURVEY=${_SURVEY},TESTID=${_TESTID}'
+    _REGION: 'us-central1'
+options:
+    dynamic_substitutions: true
+    # substitution_option: 'ALLOW_LOOSE'

--- a/classifier/cloudbuild.yaml
+++ b/classifier/cloudbuild.yaml
@@ -13,7 +13,7 @@ steps:
 substitutions:
     _SURVEY: 'elasticc'
     _TESTID: '-testid'
-    _MODULE_NAME: 'classifier${_TESTID}'
+    _MODULE_NAME: '${_SURVEY}-classifier${_TESTID}'
     _MODULE_IMAGE_NAME: 'gcr.io/${PROJECT_ID}/${_MODULE_NAME}'
     _ENV_VARS: 'GCP_PROJECT=${PROJECT_ID},SURVEY=${_SURVEY},TESTID=${_TESTID}'
     _REGION: 'us-central1'

--- a/classifier/elasticc-schema-map.yml
+++ b/classifier/elasticc-schema-map.yml
@@ -1,0 +1,20 @@
+SURVEY: elasticc
+SURVEY_SCHEMA: https://github.com/LSSTDESC/plasticc_alerts/tree/main/Examples/plasticc_schema
+SCHEMA_VERSION: v0_9
+TOPIC_SYNTAX:
+FILTER_MAP:
+objectId: [diaObject, diaObjectId]
+prvSources: prvDiaSources
+source: diaSource
+sourceId: [diaSource, diaSourceId]
+cutoutDifference: cutoutDifference
+cutoutScience: none
+cutoutTemplate: cutoutTemplate
+filter: filterName
+mag: magpsf
+magerr: sigmapsf
+magzp: magzpsci
+psFlux: psFlux
+psFluxErr: psFluxErr
+dec: decl
+ra: ra

--- a/classifier/main.py
+++ b/classifier/main.py
@@ -41,8 +41,9 @@ if TESTID != "False":  # attach the testid to the names
     ps_topic = f"{ps_topic}-{TESTID}"
 bq_table = f"{bq_dataset}.SuperNNova"
 
-schema_map = load_schema_map(SURVEY, TESTID)
 schema_out = fastavro.schema.load_schema("elasticc.v0_9.brokerClassfication.avsc")
+workingdir = Path(__file__).resolve().parent
+schema_map = load_schema_map(SURVEY, TESTID, schema=(workingdir / "elasticc-schema-map.yml"))
 alert_ids = AlertIds(schema_map)
 id_keys = alert_ids.id_keys
 

--- a/classifier/main.py
+++ b/classifier/main.py
@@ -4,6 +4,7 @@
 """Classify alerts using SuperNNova (M¨oller & de Boissi`ere 2019)."""
 
 import base64
+from datetime import datetime
 import io
 import os
 
@@ -82,7 +83,7 @@ def run(msg: dict, context) -> None:
     
     # attrs = {
     #     **msg["attributes"],
-    #     "brokerIngestTimestamp": context.timestamp,
+    #     "brokerIngestTimestamp": datetime.strptime(msg["publish_time"], '%Y-%m-%dT%H:%M:%S.%fZ'),
     #     id_keys.objectId: str(a_ids.objectId),
     #     id_keys.sourceId: str(a_ids.sourceId),
     # }

--- a/classifier/requirements.txt
+++ b/classifier/requirements.txt
@@ -1,6 +1,7 @@
 colorama
 google-cloud-functions
 google-cloud-logging
+gunicorn
 h5py
 natsort
 pgb-broker-utils==0.2.43

--- a/project-setup.sh
+++ b/project-setup.sh
@@ -1,0 +1,70 @@
+#!/usr/bin/env bash
+# Setup tasks that need to be run once per Google Cloud project
+
+# setup
+PROJECT_ID="${GOOGLE_CLOUD_PROJECT}"
+# get the project number. don't know why this is so cumbersome
+PROJECT_NUMBER=$(gcloud projects list \
+    --filter="$(gcloud config get-value project)" \
+    --format="value(PROJECT_NUMBER)" \
+    )
+
+# enable APIs
+gcloud services enable \
+    bigquery.googleapis.com \
+    iam.googleapis.com \
+    pubsub.googleapis.com \
+    run.googleapis.com
+
+
+# read the following add-iam-policy-binding commands like this:
+# gcloud <resourceType> add-iam-policy-binding <resourceName> \
+    # --member=<accountToGrantOnTheResource> \
+    # --role=<roleToGrantOnTheResource>
+# credit: https://stackoverflow.com/questions/61875357/gcloud-confusion-around-add-iam-policy-binding
+
+
+# Cloud Build needs to be able to do a bunch of things
+# grant necessary permissions to the Build service account
+build_svcact="${PROJECT_NUMBER}@cloudbuild.gserviceaccount.com"
+# Cloud Run Admin role
+role="roles/run.admin"
+gcloud projects add-iam-policy-binding "${PROJECT_ID}" \
+    --member="serviceAccount:${build_svcact}" \
+    --role="${role}"
+# permission to act as the runtime service account for Cloud Run, so it can deploy containers
+run_svcact="${PROJECT_NUMBER}-compute@developer.gserviceaccount.com"
+role="roles/iam.serviceAccountUser"
+gcloud iam service-accounts add-iam-policy-binding "${run_svcact}" \
+    --member="serviceAccount:${build_svcact}" \
+    --role="${role}"
+# # permission to create Pub/Sub subscriptions
+# role="roles/pubsub.admin"
+# gcloud projects add-iam-policy-binding "${PROJECT_ID}" \
+#     --member="serviceAccount:${build_svcact}" \
+#     --role="${role}"
+
+
+# service account for Pub/Sub subscriptions to use to invoke cloud Run
+runinvoker_name="cloud-run-invoker"
+runinvoker_svcact="${runinvoker_name}@${GOOGLE_CLOUD_PROJECT}.iam.gserviceaccount.com"
+runinvoker_dispname="Cloud Run Invoker"
+runinvoker_descrip="Service account used by Pub/Sub push subscriptions to invoke Cloud Run."
+gcloud iam service-accounts create "${runinvoker_name}" \
+    --display-name "${runinvoker_dispname}" \
+    --description "${runinvoker_descrip}"
+# give it permissions
+role="roles/run.invoker"
+gcloud projects add-iam-policy-binding "${PROJECT_ID}" \
+    --member="serviceAccount:${runinvoker_svcact}" \
+    --role="${role}"
+# run_service="classifier-testid"
+# gcloud run services add-iam-policy-binding "${run_service}" \
+#    --member="serviceAccount:${runinvoker_svcact}" \
+#    --role="${role}"
+
+
+# Allow Pub/Sub to create authentication tokens in the project
+gcloud projects add-iam-policy-binding "${PROJECT_ID}" \
+   --member="serviceAccount:service-${PROJECT_NUMBER}@gcp-sa-pubsub.iam.gserviceaccount.com" \
+   --role="roles/iam.serviceAccountTokenCreator"


### PR DESCRIPTION
This PR contains the necessary files to deploy the module to Cloud Run and attach a subscription.

Other changes that are included: bug fix for the broker ingest timestamp; switch to loading the schema map from a local file; and add/start a script that performs some one-time project setup tasks.

Example Usage:

1. Containerize and deploy:

```
SURVEY="elasticc"
TESTID="-testid"          # note the dash in front
moduledir="classifier"  # assumes you're in the repo's root dir
config="${moduledir}/cloudbuild.yaml"

gcloud builds submit --config="${config}" \
  --substitutions=_SURVEY="${SURVEY}",_TESTID="${TESTID}" \
  "${moduledir}"
```

Once the service deploys, a service URL will be printed to stdout in your terminal. You will need it below.

2. Create and attach a push subscription to trigger the module

```
topic="elasticc-loop"
topic_project="avid-heading-329016"
subscrip="elasticc-loop${TESTID}"
url="<enter the url from the previous step>"
route="/"
runinvoker_svcact="cloud-run-invoker@${GOOGLE_CLOUD_PROJECT}.iam.gserviceaccount.com"

gcloud pubsub subscriptions create "${subscrip}" \
    --topic "${topic}" \
    --topic-project "${topic_project}" \
    --ack-deadline=600 \
    --push-endpoint="${url}${route}" \
    --push-auth-service-account="${runinvoker_svcact}"
```