### PR TITLE
Add timestamp field to BigQuery table

### DIFF
--- a/classifier/main.py
+++ b/classifier/main.py
@@ -4,7 +4,7 @@
 """Classify alerts using SuperNNova (M¨oller & de Boissi`ere 2019)."""
 
 import base64
-from datetime import datetime
+from datetime import datetime, timezone
 import io
 import os
 
@@ -22,8 +22,7 @@ from broker_utils.types import AlertIds
 from broker_utils.schema_maps import load_schema_map, get_value
 from broker_utils.data_utils import open_alert
 
-from flask import Flask, request    
-
+from flask import Flask, request
 
 PROJECT_ID = os.getenv("GCP_PROJECT")
 TESTID = os.getenv("TESTID")

--- a/classifier/main.py
+++ b/classifier/main.py
@@ -132,6 +132,7 @@ def _classify_with_snn(alert_dict: dict) -> dict:
         "prob_class0": pred_probs[0].item(),
         "prob_class1": pred_probs[1].item(),
         "predicted_class": np.argmax(pred_probs).item(),
+        "timestamp": datetime.now(timezone.utc)
     }
 
     return snn_dict

--- a/classifier/main.py
+++ b/classifier/main.py
@@ -94,16 +94,7 @@ def index():
     }
 
     # classify
-    #try:
     snn_dict = _classify_with_snn(alert_dict)
-
-    # if something goes wrong, let's just log it and exit gracefully
-    # once we know more about what might go wrong, we can make this more specific
-    #except Exception as e:
-    #logger.log_text(f"Classify error: {e}", severity="WARNING")
-
-    #else:
-        # store in bigquery
     errors = gcp_utils.insert_rows_bigquery(bq_table, [snn_dict])
     if len(errors) > 0:
         logger.log_text(f"BigQuery insert error: {errors}", severity="WARNING")
@@ -171,8 +162,6 @@ def _create_elasticc_msg(alert_dict, attrs):
     classifications = [
         {
             "classifierName": "SuperNNova_v1.3",  # Troy: pin version in classify_snn
-            # Chris: fill these two in. classIds are listed here:
-            #        https://docs.google.com/presentation/d/1FwOdELG-XgdNtySeIjF62bDRVU5EsCToi2Svo_kXA50/edit#slide=id.ge52201f94a_0_12
             "classifierParams": "",  # leave this blank for now
             "classId": 111,
             "probability": supernnova_results["prob_class0"],

--- a/templates/bq_elasticc_SuperNNova_schema.json
+++ b/templates/bq_elasticc_SuperNNova_schema.json
@@ -30,7 +30,7 @@
       "type": "INTEGER"
     },
     {
-      "description": "timestamp; moment alert is ingested into project",
+      "description": "timestamp for testing",
       "mode": "REQUIRED",
       "name": "timestamp",
       "type": "TIMESTAMP"

--- a/templates/bq_elasticc_SuperNNova_schema.json
+++ b/templates/bq_elasticc_SuperNNova_schema.json
@@ -28,5 +28,11 @@
       "mode": "NULLABLE",
       "name": "predicted_class",
       "type": "INTEGER"
+    },
+    {
+      "description": "timestamp of alert processing",
+      "mode": "REQUIRED",
+      "name": "timestamp",
+      "type": "TIMESTAMP"
     }
   ]

--- a/templates/bq_elasticc_SuperNNova_schema.json
+++ b/templates/bq_elasticc_SuperNNova_schema.json
@@ -31,7 +31,7 @@
     },
     {
       "description": "timestamp for testing",
-      "mode": "REQUIRED",
+      "mode": "NULLABLE",
       "name": "timestamp",
       "type": "TIMESTAMP"
     }

--- a/templates/bq_elasticc_SuperNNova_schema.json
+++ b/templates/bq_elasticc_SuperNNova_schema.json
@@ -30,7 +30,7 @@
       "type": "INTEGER"
     },
     {
-      "description": "timestamp of alert processing",
+      "description": "timestamp; moment alert is ingested into project",
       "mode": "REQUIRED",
       "name": "timestamp",
       "type": "TIMESTAMP"


### PR DESCRIPTION
To improve our analytics, we will be adding a timestamp to future BigQuery tables containing SuperNNova classifications.

Schemas for the BigQuery table will need to be updated, and main.py will have to be updated as well.