### PR TITLE
Add additional timestamps to BigQuery table

### DIFF
--- a/classifier/main.py
+++ b/classifier/main.py
@@ -134,10 +134,9 @@ def _classify_with_snn(alert_dict: dict, attrs: dict) -> dict:
 
     # extract results to dict and attach alert/object/source ids.
     # use `.item()` to convert numpy -> python types for later json serialization
-    elasticc_alert = alert_dict["alert"]
     pred_probs = pred_probs.flatten()
     snn_dict = {
-        "alertId": elasticc_alert["alertId"],
+        "alertId": int(alert_dict["alertId"]),
         id_keys.objectId: snn_df.objectId,
         id_keys.sourceId: snn_df.sourceId,
         "prob_class0": pred_probs[0].item(),

--- a/classifier/main.py
+++ b/classifier/main.py
@@ -128,10 +128,6 @@ def _classify_with_snn(alert_dict: dict, attrs: dict) -> dict:
     # classify
     _, pred_probs = classify_lcs(snn_df, model_path, device)
 
-    # retrieve and format elasticcPublishTimestamp
-    kafka_timestamp = datetime.fromtimestamp(int(attrs["kafka.timestamp"])/1000) # converts kafka.timestamp from milliseconds to seconds
-    formatted_kafka_timestamp = kafka_timestamp.strftime("%Y-%m-%d %H:%M:%S.%f") + " UTC"
-
     # extract results to dict and attach alert/object/source ids.
     # use `.item()` to convert numpy -> python types for later json serialization
     pred_probs = pred_probs.flatten()
@@ -142,7 +138,7 @@ def _classify_with_snn(alert_dict: dict, attrs: dict) -> dict:
         "prob_class0": pred_probs[0].item(),
         "prob_class1": pred_probs[1].item(),
         "predicted_class": np.argmax(pred_probs).item(),
-        "elasticcPublishTimestamp": formatted_kafka_timestamp,
+        "elasticcPublishTimestamp": int(attrs["kafka.timestamp"])/1000,
         "brokerIngestTimestamp": attrs["brokerIngestTimestamp"],
         "classifierTimestamp": datetime.now(timezone.utc)
     }

--- a/templates/bq_elasticc_SuperNNova_schema.json
+++ b/templates/bq_elasticc_SuperNNova_schema.json
@@ -30,19 +30,19 @@
       "type": "INTEGER"
     },
     {
-      "description": "timestamp for testing",
+      "description": "timestamp from originating ELAsTiCC alert",
       "mode": "NULLABLE",
       "name": "elasticcPublishTimestamp",
       "type": "INTEGER"
     },
     {
-      "description": "timestamp for testing",
+      "description": "timestamp of broker ingestion of ELAsTiCC alert",
       "mode": "NULLABLE",
       "name": "brokerIngestTimestamp",
       "type": "TIMESTAMP"
     },
     {
-      "description": "timestamp for testing",
+      "description": "timestamp of SuperNNova classification of ELAsTiCC alert",
       "mode": "NULLABLE",
       "name": "classifierTimestamp",
       "type": "TIMESTAMP"

--- a/templates/bq_elasticc_SuperNNova_schema.json
+++ b/templates/bq_elasticc_SuperNNova_schema.json
@@ -33,7 +33,7 @@
       "description": "timestamp from originating ELAsTiCC alert",
       "mode": "NULLABLE",
       "name": "elasticcPublishTimestamp",
-      "type": "INTEGER"
+      "type": "TIMESTAMP"
     },
     {
       "description": "timestamp of broker ingestion of ELAsTiCC alert",

--- a/templates/bq_elasticc_SuperNNova_schema.json
+++ b/templates/bq_elasticc_SuperNNova_schema.json
@@ -32,7 +32,19 @@
     {
       "description": "timestamp for testing",
       "mode": "NULLABLE",
-      "name": "timestamp",
+      "name": "elasticcPublishTimestamp",
+      "type": "INTEGER"
+    },
+    {
+      "description": "timestamp for testing",
+      "mode": "NULLABLE",
+      "name": "brokerIngestTimestamp",
+      "type": "TIMESTAMP"
+    },
+    {
+      "description": "timestamp for testing",
+      "mode": "NULLABLE",
+      "name": "classifierTimestamp",
       "type": "TIMESTAMP"
     }
   ]

--- a/templates/bq_elasticc_SuperNNova_schema.json
+++ b/templates/bq_elasticc_SuperNNova_schema.json
@@ -1,9 +1,15 @@
 [
     {
+      "description": "unique alert identifer",
+      "mode": "REQUIRED",
+      "name": "alertId",
+      "type": "INTEGER"
+    },
+    {
       "description": "object identifier or name",
       "mode": "REQUIRED",
       "name": "diaObjectId",
-      "type": "STRING"
+      "type": "INTEGER"
     },
     {
       "description": "Candidate ID from operations DB",


### PR DESCRIPTION
In order to create metrics of the processing time of alerts in our pipeline for the ELAsTiCC2 challenge, additional parameters need to be added into the BigQuery table.

The following timestamps are added in this PR:
- `elasticcPublishTimestamp`
- `brokerIngestTimestamp`
- `classifierTimestamp` (previously just called `timestamp`)

The following files are modified:
- `main.py`
- `bq_elasticc_SuperNNova_schema.json`

These updates have been tested. A classifier instance with `testid = timestamp` was [deployed](https://console.cloud.google.com/run/detail/us-central1/elasticc-classifier-timestamp/metrics?project=elasticc-challenge) (with `trigger_topic = elasticc-loop`), and the classifications were written to the following BigQuery table: [`elasticc_alerts_timestamp`](https://console.cloud.google.com/bigquery?project=elasticc-challenge&ws=!1m5!1m4!4m3!1selasticc-challenge!2selasticc_alerts_timestamp!3sSuperNNova)