### PR TITLE
Update supernova classifier module version from `v0.6` to `v0.7`

### DIFF
--- a/classifier/main.py
+++ b/classifier/main.py
@@ -28,6 +28,9 @@ PROJECT_ID = os.getenv("GCP_PROJECT")
 TESTID = os.getenv("TESTID")
 SURVEY = os.getenv("SURVEY")
 
+# specify module version
+brokerVersion = "v0.7"
+
 # connect to the logger
 logging_client = logging.Client()
 log_name = "classify-snn-cloudrun"  # same log for all broker instances
@@ -132,7 +135,6 @@ def _classify_with_snn(alert_dict: dict, attrs: dict) -> dict:
     # extract results to dict and attach alert/object/source ids.
     # use `.item()` to convert numpy -> python types for later json serialization
     pred_probs = pred_probs.flatten()
-    brokerVersion = "v0.7"
     snn_dict = {
         "alertId": int(alert_dict["alertId"]),
         id_keys.objectId: snn_df.objectId,
@@ -177,7 +179,6 @@ def _create_elasticc_msg(alert_dict, attrs):
     # here are a few things you'll need
     elasticcPublishTimestamp = int(attrs["kafka.timestamp"])
     brokerIngestTimestamp = attrs.pop("brokerIngestTimestamp")
-    brokerVersion = "v0.7"
 
     classifications = [
         {

--- a/classifier/main.py
+++ b/classifier/main.py
@@ -62,6 +62,7 @@ bq_schema = [
     bigquery.SchemaField("prob_class0", "FLOAT"),
     bigquery.SchemaField("prob_class1", "FLOAT"),
     bigquery.SchemaField("predicted_class", "INTEGER"),
+    bigquery.SchemaField("brokerVersion", "STRING"),
     bigquery.SchemaField("elasticcPublishTimestamp", "TIMESTAMP"),
     bigquery.SchemaField("brokerIngestTimestamp", "TIMESTAMP"),
     bigquery.SchemaField("classifierTimestamp", "TIMESTAMP")
@@ -131,6 +132,7 @@ def _classify_with_snn(alert_dict: dict, attrs: dict) -> dict:
     # extract results to dict and attach alert/object/source ids.
     # use `.item()` to convert numpy -> python types for later json serialization
     pred_probs = pred_probs.flatten()
+    brokerVersion = "v0.7"
     snn_dict = {
         "alertId": int(alert_dict["alertId"]),
         id_keys.objectId: snn_df.objectId,
@@ -138,6 +140,7 @@ def _classify_with_snn(alert_dict: dict, attrs: dict) -> dict:
         "prob_class0": pred_probs[0].item(),
         "prob_class1": pred_probs[1].item(),
         "predicted_class": np.argmax(pred_probs).item(),
+        "brokerVersion": brokerVersion,
         "elasticcPublishTimestamp": int(attrs["kafka.timestamp"])/1000,
         "brokerIngestTimestamp": attrs["brokerIngestTimestamp"],
         "classifierTimestamp": datetime.now(timezone.utc)

--- a/classifier/main.py
+++ b/classifier/main.py
@@ -169,7 +169,7 @@ def _create_elasticc_msg(alert_dict, attrs):
     # here are a few things you'll need
     elasticcPublishTimestamp = int(attrs["kafka.timestamp"])
     brokerIngestTimestamp = attrs.pop("brokerIngestTimestamp")
-    brokerVersion = "v0.6"
+    brokerVersion = "v0.7"
 
     classifications = [
         {

--- a/templates/bq_elasticc_SuperNNova_schema.json
+++ b/templates/bq_elasticc_SuperNNova_schema.json
@@ -36,6 +36,12 @@
       "type": "INTEGER"
     },
     {
+      "description": "classifier module version",
+      "mode": "NULLABLE",
+      "name": "brokerVersion",
+      "type": "STRING"
+    },
+    {
       "description": "timestamp from originating ELAsTiCC alert",
       "mode": "NULLABLE",
       "name": "elasticcPublishTimestamp",


### PR DESCRIPTION
Since the start of the original ELAsTiCC challenge, the supernova classifier module has undergone a few changes. These changes were introduced without declaring an updated version (currently `v0.6`). For the ELAsTiCC2 challenge, we are formalizing the module's version as `v0.7`. 

For the ELAsTiCC2 challenge, we have:
- updated `main.py` and `bq_elasticc_SuperNNova_schema.json` to include additional fields in the BigQuery table
- updated `main.py` to accommodate ELAsTiCC's [new schema](https://github.com/LSSTDESC/elasticc/tree/main/alert_schema) (`v0.9.1`)
- generalized variable and function names

Future updates to the classifier module will result in updated version declarations.

Should this PR should be merged after merging PR #20?